### PR TITLE
Get rid of owner id from account and team items

### DIFF
--- a/app/pages/teams/members/members.component.ts
+++ b/app/pages/teams/members/members.component.ts
@@ -51,7 +51,7 @@ export class MembersComponent implements OnInit {
         this.teamDescription = this.team.teamDescription;
         this.teamName = this.team.teamName;
         this.isOwner =
-          this.team.ownerId === this.accountService.account.ownerId
+          this.team.ownerEmail === this.accountService.account.email
             ? true
             : false;
       },

--- a/app/shared/models/account.ts
+++ b/app/shared/models/account.ts
@@ -9,7 +9,6 @@ export interface AccountServerInterface {
 }
 
 export class Account {
-  private _ownerId: number;
   private _firstname: string;
   private _lastname: string;
   private _email: string;
@@ -18,7 +17,6 @@ export class Account {
   private _serverUrl: string;
 
   constructor(account: AccountServerInterface) {
-    this._ownerId = account.ownerId;
     this._email = account.email;
     this._firstname = account.firstName;
     this._lastname = account.lastName;
@@ -26,20 +24,10 @@ export class Account {
   }
 
   fromServer(account: AccountServerInterface) {
-    this._ownerId = account.ownerId;
     this._email = account.email;
     this._firstname = account.firstName;
     this._lastname = account.lastName;
     this._isDeleted = account.isDeleted;
-  }
-
-  get ownerId(): number {
-    return this._ownerId;
-  }
-
-  //  Set/get for email
-  set email(newEmail: string) {
-    this._email = newEmail;
   }
 
   get email(): string {

--- a/app/shared/models/account.ts
+++ b/app/shared/models/account.ts
@@ -1,7 +1,6 @@
 //  account.ts contains the account class
 
 export interface AccountServerInterface {
-  ownerId: number;
   firstName: string;
   lastName: string;
   email: string;

--- a/app/shared/models/team.ts
+++ b/app/shared/models/team.ts
@@ -3,20 +3,20 @@ export interface TeamServerInterface {
   id: number;
   teamName: string;
   teamDescription: string;
-  ownerId: number;
+  ownerEmail: string;
 }
 
 export class Team {
   private _id: number = 0; //the unique ID for a team
   private _teamName: string; //the name for a team
   private _teamDescription: string; //the description for a team
-  private _ownerId: number;
+  private _ownerEmail: string;
 
   constructor(team: TeamServerInterface) {
     this._id = team.id;
     this._teamName = team.teamName;
     this._teamDescription = team.teamDescription;
-    this._ownerId = team.ownerId;
+    this._ownerEmail = team.ownerEmail;
   }
 
   public set id(id: number) {
@@ -43,11 +43,11 @@ export class Team {
     return this._teamDescription;
   }
 
-  public set ownerId(id: number) {
-    this._ownerId = id;
+  public set ownerEmail(email: string) {
+    this._ownerEmail = email;
   }
 
-  public get ownerId(): number {
-    return this._ownerId;
+  public get ownerEmail(): string {
+    return this._ownerEmail;
   }
 }

--- a/app/shared/services/account.service.ts
+++ b/app/shared/services/account.service.ts
@@ -19,21 +19,18 @@ export class AccountService {
     let email = AppSettings.getString('email', '');
     let firstname = AppSettings.getString('firstname', '');
     let lastname = AppSettings.getString('lastname', '');
-    let ownerId = AppSettings.getNumber('ownerId', -1);
     let serverUrl = AppSettings.getString('serverUrl', '');
 
     if (
       email === '' ||
       firstname === '' ||
       lastname === '' ||
-      ownerId === -1 ||
       serverUrl === ''
     ) {
       this._account = null;
       this._state = State.LoggedOut;
     } else {
       let account = new Account({
-        ownerId: ownerId,
         firstName: firstname,
         lastName: lastname,
         email: email,
@@ -69,7 +66,6 @@ export class AccountService {
     AppSettings.setString('email', account.email);
     AppSettings.setString('firstname', account.firstname);
     AppSettings.setString('lastname', account.lastname);
-    AppSettings.setNumber('ownerId', account.ownerId);
     AppSettings.setString('serverUrl', account.serverUrl);
     //appSettings.setString("token", account.token);
   }

--- a/app/shared/services/server.service.ts
+++ b/app/shared/services/server.service.ts
@@ -105,7 +105,7 @@ export class ServerService {
   addTeam(name: string, description: string) {
     let endpoint = this._url + '/api/team';
     let body = {
-      ownerId: this.accountService.account.ownerId,
+      ownerEmail: this.accountService.account.email,
       teamName: name,
       teamDescription: description
     };


### PR DESCRIPTION
On the backend, email is used instead of account ids.

This changes the existing uses of ownerid so that email is used instead.